### PR TITLE
speedup using response header

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,7 +48,7 @@ export default function Home() {
 					const diff = Math.random() * 10;
 					return Math.min(oldProgress + diff, 100);
 				});
-			}, 300);
+			}, 100);
 			return () => {
 				clearInterval(interval);
 			};


### PR DESCRIPTION
Originally I was doing a binary search, which required about 15 searches through the github api for each search.

I used the following repository implementation as a reference to find the first commit from the response header.
This will reduce the number of requests to the github api to just a few.
https://github.com/khalidbelk/FirstCommitter