### PR TITLE
chore: group dependabot updates and pin actions to commit hashes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,17 +5,21 @@ updates:
     schedule:
       interval: "monthly"
     groups:
+      patch:
+        update-types:
+          - "patch"
       development:
         patterns:
           - "@types/*"
           - "@cloudflare/workers-types"
           - "@octokit/types"
           - "@biomejs/*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
     groups:
-      github-actions:
+      all-actions:
         patterns:
           - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Delete Preview Worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install dependencies
         run: npm ci
@@ -23,14 +23,14 @@ jobs:
 
       - name: Deploy Preview to Cloudflare Workers
         id: deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy --name "git-first-commit-pr-${{ github.event.pull_request.number }}" --var PUBLIC_URL:"https://git-first-commit-pr-${{ github.event.pull_request.number }}.2wua4nlyi4102.workers.dev" --var ENV:preview
 
       - name: Comment Preview URL on PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const prNumber = context.issue.number;


### PR DESCRIPTION
## Summary

Standardize Dependabot grouping rules and pin GitHub Actions to commit hashes.

- Add `patch` group (`update-types: ["patch"]`) for non-actions / non-terraform ecosystems so that patch-level updates land in a single PR.
- Group all GitHub Actions into `all-actions` and Terraform providers into `all-providers` (where applicable).
- Pin all GitHub Actions referenced in `.github/workflows/*.yml` to commit hashes using [pinact](https://github.com/suzuki-shunsuke/pinact). The version comment after each hash lets Dependabot continue to bump them.

## Test plan

- [ ] Confirm Dependabot UI accepts the new config (no errors on next scheduled run)
- [ ] Confirm existing workflows still pass